### PR TITLE
Add blockquote formatting for gems

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -79,7 +79,7 @@ bot.reaction_added(function(e) {
                 }
               }
               if (message.ts == ts && message.user == gemUserId && gemUser.name !== 'gem-me-bot' && count === 1) {
-                text = `${minerUser.name}: "${message.text}" \n- @${gemUser.name}`
+                ext = `>“${message.text}”\n>— @${gemUser.name} \n_posted by @${minerUser.name}_`
                 slack.chat.postMessage({token: type.token, channel: type.channel, text: text, as_user: true, username: type.bot}, function(err, data) {
                   console.log(`sent a ${type.name} message to ${type.channel} channel.`);
                 });


### PR DESCRIPTION
This adds in Slack’s formatting for block quotes to gems appearing in the channel.